### PR TITLE
feat: ESM worker support

### DIFF
--- a/src/fakeWorker.test.ts
+++ b/src/fakeWorker.test.ts
@@ -1,78 +1,99 @@
 import { FakeWorker } from './fakeWorker'
-import { test, expect } from 'vitest'
-import type querystring from 'node:querystring'
+import { test, expect, describe } from 'vitest'
+import querystring from 'node:querystring'
 
-test('should work', async () => {
-  const worker = new FakeWorker(() => {
-    return async ({ n }) => {
-      return new Promise((r) => {
-        setTimeout(
-          () => {
-            r(n + 1)
-          },
-          Math.floor(Math.random() * 100)
-        )
-      })
-    }
+for (const ty of ['module', 'classic'] as const) {
+  describe(`type: ${ty}`, () => {
+    test('should work', async () => {
+      const worker = new FakeWorker(
+        () => {
+          return async ({ n }) => {
+            return new Promise((r) => {
+              setTimeout(
+                () => {
+                  r(n + 1)
+                },
+                Math.floor(Math.random() * 100)
+              )
+            })
+          }
+        },
+        { type: ty }
+      )
+
+      const results = await Promise.all([
+        worker.run({ n: 1 }),
+        worker.run({ n: 2 }),
+        worker.run({ n: 3 }),
+        worker.run({ n: 4 }),
+        worker.run({ n: 5 }),
+        worker.run({ n: 6 }),
+        worker.run({ n: 7 }),
+        worker.run({ n: 8 }),
+        worker.run({ n: 9 })
+      ])
+
+      worker.stop()
+      expect(results).toStrictEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
+    })
+
+    test('require works', async () => {
+      const worker = new FakeWorker(
+        ty === 'classic'
+          ? () => {
+              // eslint-disable-next-line @typescript-eslint/no-require-imports
+              const qs: typeof querystring = require('node:querystring')
+              return async () => {
+                return qs.stringify({ foo: 'bar' })
+              }
+            }
+          : async () => {
+              const qs: typeof querystring = await import('node:querystring')
+              return async () => {
+                return qs.stringify({ foo: 'bar' })
+              }
+            },
+        { type: ty }
+      )
+
+      const result = await worker.run()
+
+      worker.stop()
+      expect(result).toBe(querystring.stringify({ foo: 'bar' }))
+    })
+
+    test('parentFunction', async () => {
+      const parent = async () => 1
+      const worker = new FakeWorker(
+        () => async () => {
+          return (await parent()) + 1
+        },
+        {
+          type: ty,
+          parentFunctions: { parent }
+        }
+      )
+
+      const result = await worker.run()
+
+      worker.stop()
+      expect(result).toBe(2)
+    })
+
+    test('missing parentFunction', async () => {
+      let missing!: () => Promise<number>
+      const worker = new FakeWorker(
+        () => async () => {
+          return (await missing()) + 1
+        },
+        { type: ty }
+      )
+
+      await expect(() => worker.run()).rejects.toThrow(
+        'missing is not defined. ' +
+          'Maybe you forgot to pass the function to parentFunction?'
+      )
+      worker.stop()
+    })
   })
-
-  const results = await Promise.all([
-    worker.run({ n: 1 }),
-    worker.run({ n: 2 }),
-    worker.run({ n: 3 }),
-    worker.run({ n: 4 }),
-    worker.run({ n: 5 }),
-    worker.run({ n: 6 }),
-    worker.run({ n: 7 }),
-    worker.run({ n: 8 }),
-    worker.run({ n: 9 })
-  ])
-
-  worker.stop()
-  expect(results).toStrictEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
-})
-
-test('require works', async () => {
-  const worker = new FakeWorker(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const qs: typeof querystring = require('node:querystring')
-    return async () => {
-      return qs.stringify({ foo: 'bar' })
-    }
-  })
-
-  const result = await worker.run()
-
-  worker.stop()
-  expect(result).toMatchInlineSnapshot('"foo=bar"')
-})
-
-test('parentFunction', async () => {
-  const parent = async () => 1
-  const worker = new FakeWorker(
-    () => async () => {
-      return (await parent()) + 1
-    },
-    {
-      parentFunctions: { parent }
-    }
-  )
-
-  const result = await worker.run()
-
-  worker.stop()
-  expect(result).toBe(2)
-})
-
-test('missing parentFunction', async () => {
-  let missing!: () => Promise<number>
-  const worker = new FakeWorker(() => async () => {
-    return (await missing()) + 1
-  })
-
-  await expect(() => worker.run()).rejects.toThrow(
-    'missing is not defined. ' +
-      'Maybe you forgot to pass the function to parentFunction?'
-  )
-  worker.stop()
-})
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,12 @@ export type ParentFunctions = Record<
 
 export interface Options {
   /**
+   * Whether the passed code should be treated as a module or a commonjs script
+   *
+   * @default 'classic'
+   */
+  type?: 'module' | 'classic'
+  /**
    * Max number of workers that can be spawned at the same time
    */
   max?: number

--- a/src/realWorker.test.ts
+++ b/src/realWorker.test.ts
@@ -1,113 +1,127 @@
 import { Worker } from './realWorker'
-import { test, expect } from 'vitest'
-import type querystring from 'node:querystring'
+import { test, expect, describe } from 'vitest'
+import querystring from 'node:querystring'
 
-test('should work', async () => {
-  const worker = new Worker(() => {
-    return async ({ n }) => {
-      return new Promise((r) => {
-        setTimeout(
-          () => {
-            r(n + 1)
-          },
-          Math.floor(Math.random() * 100)
-        )
+for (const ty of ['module', 'classic'] as const) {
+  describe(`type: ${ty}`, () => {
+    test('should work', async () => {
+      const worker = new Worker(
+        () => {
+          return async ({ n }) => {
+            return new Promise((r) => {
+              setTimeout(
+                () => {
+                  r(n + 1)
+                },
+                Math.floor(Math.random() * 100)
+              )
+            })
+          }
+        },
+        { type: ty }
+      )
+
+      const results = await Promise.all([
+        worker.run({ n: 1 }),
+        worker.run({ n: 2 }),
+        worker.run({ n: 3 }),
+        worker.run({ n: 4 }),
+        worker.run({ n: 5 }),
+        worker.run({ n: 6 }),
+        worker.run({ n: 7 }),
+        worker.run({ n: 8 }),
+        worker.run({ n: 9 })
+      ])
+
+      worker.stop()
+      expect(results).toStrictEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
+    })
+
+    test('max option', async () => {
+      const worker = new Worker(
+        () => async () => {
+          await new Promise((resolve) => setTimeout(resolve, 50))
+          return 1
+        },
+        { max: 1, type: ty }
+      )
+
+      const start = Date.now()
+      const results = await Promise.all([worker.run(), worker.run()])
+      const elapsed = Date.now() - start
+
+      worker.stop()
+      expect(results).toStrictEqual([1, 1])
+      expect(elapsed).toBeGreaterThan(75)
+    })
+
+    test('require works', async () => {
+      const worker = new Worker(
+        ty === 'classic'
+          ? () => {
+              // eslint-disable-next-line @typescript-eslint/no-require-imports
+              const qs: typeof querystring = require('node:querystring')
+              return async () => {
+                return qs.stringify({ foo: 'bar' })
+              }
+            }
+          : async () => {
+              const qs: typeof querystring = await import('node:querystring')
+              return async () => {
+                return qs.stringify({ foo: 'bar' })
+              }
+            },
+        { type: ty }
+      )
+
+      const result = await worker.run()
+
+      worker.stop()
+      expect(result).toBe(querystring.stringify({ foo: 'bar' }))
+    })
+
+    test('parentFunction', async () => {
+      const parent = async () => 1
+      const worker = new Worker(
+        () => async () => {
+          return (await parent()) + 1
+        },
+        {
+          type: ty,
+          parentFunctions: { parent }
+        }
+      )
+
+      const result = await worker.run()
+
+      worker.stop()
+      expect(result).toBe(2)
+    })
+
+    test('missing parentFunction', async () => {
+      let missing!: () => Promise<number>
+      const worker = new Worker(() => async () => {
+        return (await missing()) + 1
       })
-    }
+
+      await expect(() => worker.run()).rejects.toThrow(
+        'missing is not defined. ' +
+          'Maybe you forgot to pass the function to parentFunction?'
+      )
+      worker.stop()
+    })
+
+    test('call done for rejected call', { timeout: 300 }, async () => {
+      const worker = new Worker(
+        () => async () => {
+          throw new Error('throw')
+        },
+        { max: 1, type: ty }
+      )
+
+      await expect(() => worker.run()).rejects.toThrow()
+      await expect(() => worker.run()).rejects.toThrow()
+      worker.stop()
+    })
   })
-
-  const results = await Promise.all([
-    worker.run({ n: 1 }),
-    worker.run({ n: 2 }),
-    worker.run({ n: 3 }),
-    worker.run({ n: 4 }),
-    worker.run({ n: 5 }),
-    worker.run({ n: 6 }),
-    worker.run({ n: 7 }),
-    worker.run({ n: 8 }),
-    worker.run({ n: 9 })
-  ])
-
-  worker.stop()
-  expect(results).toStrictEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
-})
-
-test('max option', async () => {
-  const worker = new Worker(
-    () => async () => {
-      await new Promise((resolve) => setTimeout(resolve, 50))
-      return 1
-    },
-    { max: 1 }
-  )
-
-  const start = Date.now()
-  const results = await Promise.all([worker.run(), worker.run()])
-  const elapsed = Date.now() - start
-
-  worker.stop()
-  expect(results).toStrictEqual([1, 1])
-  expect(elapsed).toBeGreaterThan(75)
-})
-
-test('require works', async () => {
-  const worker = new Worker(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const qs: typeof querystring = require('node:querystring')
-    return async () => {
-      return qs.stringify({ foo: 'bar' })
-    }
-  })
-
-  const result = await worker.run()
-
-  worker.stop()
-  expect(result).toMatchInlineSnapshot('"foo=bar"')
-})
-
-test('parentFunction', async () => {
-  const parent = async () => 1
-  const worker = new Worker(
-    () => async () => {
-      return (await parent()) + 1
-    },
-    {
-      parentFunctions: { parent }
-    }
-  )
-
-  const result = await worker.run()
-
-  worker.stop()
-  expect(result).toBe(2)
-})
-
-test('missing parentFunction', async () => {
-  let missing!: () => Promise<number>
-  const worker = new Worker(() => async () => {
-    return (await missing()) + 1
-  })
-
-  await expect(() => worker.run()).rejects.toThrow(
-    'missing is not defined. ' +
-      'Maybe you forgot to pass the function to parentFunction?'
-  )
-  worker.stop()
-})
-
-test(
-  'call done for rejected call',
-  async () => {
-    const worker = new Worker(
-      () => async () => {
-        throw new Error('throw')
-      },
-      { max: 1 }
-    )
-
-    await expect(() => worker.run()).rejects.toThrow()
-    await expect(() => worker.run()).rejects.toThrow()
-    worker.stop()
-  },
-  { timeout: 300 }
-)
+}

--- a/src/realWorker.ts
+++ b/src/realWorker.ts
@@ -195,7 +195,7 @@ function genWorkerCode(
 
   const fnString = fn
     .toString()
-    // also replace `__vite_ssr_dynamic_import__` for vitest compatibility
+    // replace `__vite_ssr_dynamic_import__` for vitest compatibility
     .replaceAll(viteSsrDynamicImport, 'import')
 
   return `

--- a/src/realWorker.ts
+++ b/src/realWorker.ts
@@ -1,6 +1,7 @@
 import os from 'node:os'
 import { Worker as _Worker } from 'node:worker_threads'
 import type { Options, ParentFunctions } from './options'
+import { codeToDataUrl, viteSsrDynamicImport, type MaybePromise } from './utils'
 
 interface NodeWorker<Ret> extends _Worker {
   currentResolve: ((value: Ret | PromiseLike<Ret>) => void) | null
@@ -8,6 +9,8 @@ interface NodeWorker<Ret> extends _Worker {
 }
 
 export class Worker<Args extends unknown[], Ret = unknown> {
+  /** @internal */
+  private _isModule: boolean
   /** @internal */
   private _code: string
   /** @internal */
@@ -22,10 +25,15 @@ export class Worker<Args extends unknown[], Ret = unknown> {
   private _queue: [(worker: NodeWorker<Ret>) => void, (err: Error) => void][]
 
   constructor(
-    fn: () => (...args: Args) => Promise<Ret> | Ret,
+    fn: () => MaybePromise<(...args: Args) => MaybePromise<Ret>>,
     options: Options = {}
   ) {
-    this._code = genWorkerCode(fn, options.parentFunctions ?? {})
+    this._isModule = options.type === 'module'
+    this._code = genWorkerCode(
+      fn,
+      this._isModule,
+      options.parentFunctions ?? {}
+    )
     this._parentFunctions = options.parentFunctions ?? {}
     const defaultMax = Math.max(
       1,
@@ -68,7 +76,11 @@ export class Worker<Args extends unknown[], Ret = unknown> {
 
     // can spawn more?
     if (this._pool.length < this._max) {
-      const worker = new _Worker(this._code, { eval: true }) as NodeWorker<Ret>
+      const worker = (
+        this._isModule
+          ? new _Worker(new URL(codeToDataUrl(this._code)))
+          : new _Worker(this._code, { eval: true })
+      ) as NodeWorker<Ret>
 
       worker.on('message', async (args) => {
         if (args.type === 'run') {
@@ -144,7 +156,8 @@ export class Worker<Args extends unknown[], Ret = unknown> {
 
 function genWorkerCode(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  fn: () => Function,
+  fn: () => MaybePromise<Function>,
+  isModule: boolean,
   parentFunctions: ParentFunctions
 ) {
   const createParentFunctionCaller = (parentPort: MessagePort) => {
@@ -180,21 +193,29 @@ function genWorkerCode(
     return { call, receive }
   }
 
+  const fnString = fn
+    .toString()
+    // also replace `__vite_ssr_dynamic_import__` for vitest compatibility
+    .replaceAll(viteSsrDynamicImport, 'import')
+
   return `
-const { parentPort } = require('worker_threads')
+${isModule ? "import { parentPort } from 'worker_threads'" : "const { parentPort } = require('worker_threads')"}
 const parentFunctionCaller = (${createParentFunctionCaller.toString()})(parentPort)
 
-const doWork = (() => {
+const doWorkPromise = (async () => {
   ${Object.keys(parentFunctions)
     .map(
       (key) =>
         `const ${key} = parentFunctionCaller.call(${JSON.stringify(key)});`
     )
     .join('\n')}
-  return (${fn.toString()})()
+  return await (${fnString})()
 })()
+let doWork
 
 parentPort.on('message', async (args) => {
+  doWork ||= await doWorkPromise
+
   if (args.type === 'run') {
     try {
       const res = await doWork(...args.args)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+export type MaybePromise<T> = T | Promise<T>
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const AsyncFunction = async function () {}.constructor as typeof Function
+
+export const codeToDataUrl = (code: string) =>
+  `data:application/javascript,${encodeURIComponent(code + '\n//# sourceURL=[worker-eval(artichokie)]')}`
+
+export const viteSsrDynamicImport = '__vite_ssr_dynamic_import__'

--- a/src/workerWithFallback.test.ts
+++ b/src/workerWithFallback.test.ts
@@ -1,67 +1,74 @@
 import { WorkerWithFallback } from './workerWithFallback'
-import { test, expect } from 'vitest'
+import { test, expect, describe } from 'vitest'
 
-test('should work', async () => {
-  const infSymbol = Symbol('inf')
-  const isInf = async (n: number | symbol) => n === infSymbol
+for (const ty of ['module', 'classic'] as const) {
+  describe(`type: ${ty}`, () => {
+    test('should work', async () => {
+      const infSymbol = Symbol('inf')
+      const isInf = async (n: number | symbol) => n === infSymbol
 
-  const worker = new WorkerWithFallback(
-    () => async (n: number | symbol) => {
-      return (await isInf(n)) ? Infinity : 0
-    },
-    {
-      parentFunctions: { isInf },
-      shouldUseFake(n) {
-        return typeof n === 'symbol'
-      }
-    }
-  )
+      const worker = new WorkerWithFallback(
+        () => async (n: number | symbol) => {
+          return (await isInf(n)) ? Infinity : 0
+        },
+        {
+          type: ty,
+          parentFunctions: { isInf },
+          shouldUseFake(n) {
+            return typeof n === 'symbol'
+          }
+        }
+      )
 
-  const results = await Promise.all([worker.run(1), worker.run(infSymbol)])
+      const results = await Promise.all([worker.run(1), worker.run(infSymbol)])
 
-  worker.stop()
-  expect(results).toStrictEqual([0, Infinity])
-})
+      worker.stop()
+      expect(results).toStrictEqual([0, Infinity])
+    })
 
-test('should error', async () => {
-  const infSymbol = Symbol('inf')
-  const isInf = async (n: number | symbol) => n === infSymbol
+    test('should error', async () => {
+      const infSymbol = Symbol('inf')
+      const isInf = async (n: number | symbol) => n === infSymbol
 
-  const worker = new WorkerWithFallback(
-    () => async (n: number | symbol) => {
-      return (await isInf(n)) ? Infinity : 0
-    },
-    {
-      parentFunctions: { isInf },
-      shouldUseFake() {
-        return false
-      }
-    }
-  )
+      const worker = new WorkerWithFallback(
+        () => async (n: number | symbol) => {
+          return (await isInf(n)) ? Infinity : 0
+        },
+        {
+          type: ty,
+          parentFunctions: { isInf },
+          shouldUseFake() {
+            return false
+          }
+        }
+      )
 
-  await expect(() => worker.run(infSymbol)).rejects.toThrow()
-  worker.stop()
-})
+      await expect(() => worker.run(infSymbol)).rejects.toThrow()
+      worker.stop()
+    })
 
-test('should use fake if max=0', async () => {
-  const infSymbol = Symbol('inf')
-  const isInf = async (n: number | symbol) => n === infSymbol
+    test('should use fake if max=0', async () => {
+      const infSymbol = Symbol('inf')
+      const isInf = async (n: number | symbol) => n === infSymbol
 
-  const worker = new WorkerWithFallback(
-    () => async (n: number | symbol) => {
-      return (await isInf(n)) ? Infinity : 0
-    },
-    {
-      parentFunctions: { isInf },
-      shouldUseFake() {
-        return false
-      },
-      max: 0
-    }
-  )
+      const worker = new WorkerWithFallback(
+        () => async (n: number | symbol) => {
+          return (await isInf(n)) ? Infinity : 0
+        },
+        {
+          type: ty,
+          parentFunctions: { isInf },
+          shouldUseFake() {
+            return false
+          },
+          max: 0
+        }
+      )
 
-  const result = await worker.run(infSymbol)
+      const result = await worker.run(infSymbol)
 
-  worker.stop()
-  expect(result).toStrictEqual(Infinity)
-})
+      worker.stop()
+      expect(result).toStrictEqual(Infinity)
+    })
+  })
+}


### PR DESCRIPTION
`type: "module"` can now be passed to `Worker`/`WorkerWithFallback`.